### PR TITLE
Support shinyserver

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,5 @@ $run_dev.*
 ^NEWS\.md$
 ^\.Rdata$
 ^\.Rhistory$
+^app\.R$
+^rsconnect$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Imports:
     htmltools,
     ggplot2,
     graphics,
-    utils
+    utils,
+    pkgload
 Encoding: UTF-8
 biocViews: Microbiome, Software, Visualization,KEGG
 RoxygenNote: 7.1.2

--- a/R/_disable_autoload.R
+++ b/R/_disable_autoload.R
@@ -1,0 +1,3 @@
+# Disabling shiny autoload
+
+# See ?shiny::loadSupport for more information

--- a/app.R
+++ b/app.R
@@ -1,0 +1,7 @@
+# Launch the ShinyApp (Do not remove this comment)
+# To deploy, run: rsconnect::deployApp()
+# Or use the blue button on top of this file
+
+pkgload::load_all(export_all = FALSE,helpers = FALSE,attach_testthat = FALSE)
+options( "golem.app.prod" = TRUE)
+MicrobiomeProfiler::run_MicrobiomeProfiler() # add parameters here (if any)


### PR DESCRIPTION
I created the app.R file using `golem::add_shinyserver_file(".")` based on https://engineering-shiny.org/deploy.html#deploying-apps-with-golem .

Then this package can be used on shiny-server.